### PR TITLE
Remove spinkit in Podfile

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -24,6 +24,4 @@ target 'pcnkflex' do
   pod 'Fabric', '~> 1.7.6'
   pod 'Crashlytics', '~> 3.10.1'
 
-  pod 'react-native-spinkit', :path => '../node_modules/react-native-spinkit'
-
 end


### PR DESCRIPTION
No longer need spinkit pod. (If we don't remove it, it will cause error on 'pod install'.)